### PR TITLE
Feature: Employee CRUD

### DIFF
--- a/app/api/v1/endpoints/employee.py
+++ b/app/api/v1/endpoints/employee.py
@@ -3,18 +3,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_async_session
 from app.core.user import current_user
+from app.crud import user_crud
 from app.models import User
-from app.schemas import UserRead
+from app.schemas import UserShort
 
 router = APIRouter()
 
 
 @router.get(
     '/employees',
-    response_model=list[UserRead],
+    response_model=list[UserShort],
+    response_model_exclude={'is_active'},
 )
 async def get_employees(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_user),
 ):
-    return {None}
+    data = await user_crud.get_employees(session=session, user_id=user.id)
+    return data

--- a/app/crud/mixin.py
+++ b/app/crud/mixin.py
@@ -1,0 +1,22 @@
+from typing import Generator, Iterable
+
+from sqlalchemy import Row
+
+from app.models import PDP, User
+
+
+class StatisticMixin:
+    @staticmethod
+    def _add_statistic_to_dpd(pdp: PDP, done: int, total: int) -> PDP:
+        pdp.__setattr__('done', done)
+        pdp.__setattr__('total', total)
+        return pdp
+
+    @staticmethod
+    def _add_user_statistic_generator(
+        rows: Iterable[Row[tuple[User, int, int]]]
+    ) -> Generator:
+        for row in rows:
+            user, done, total = row
+            StatisticMixin._add_statistic_to_dpd(user.pdp, done, total)
+            yield user

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,10 +1,54 @@
-from app.models import User
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased, joinedload
+
+from app.models import PDP, Status, Task, User
+from app.models.user import user_user
 
 from .base import CRUDBase
+from .mixin import StatisticMixin
 
 
-class CRUDUser(CRUDBase):
-    ...
+class CRUDUser(CRUDBase, StatisticMixin):
+    async def get_employees(
+        self,
+        user_id: int,
+        session: AsyncSession,
+    ):
+        status_alias = aliased(Status)
+        task_alias = aliased(Task)
+
+        done_subquery = (
+            select(func.count())
+            .select_from(PDP)
+            .join(task_alias, task_alias.pdp_id == PDP.id)
+            .where(PDP.user_id == user_user.c.user_id)
+            .join(user_user, user_user.c.user_id == User.id)
+            .where(user_user.c.chief_id == user_id)
+            .join(status_alias, status_alias.id == task_alias.status_id)
+            .where(
+                status_alias.name.in_(["исполнено", "выполнено", "отменено"])
+            )
+            .label("done")
+        )
+        total_subquery = (
+            select(func.count())
+            .select_from(PDP)
+            .join(task_alias, task_alias.pdp_id == PDP.id)
+            .where(PDP.user_id == user_user.c.user_id)
+            .join(user_user, user_user.c.user_id == User.id)
+            .where(user_user.c.chief_id == user_id)
+            .group_by(self.model)
+            .label("total")
+        )
+        db_obj = await session.execute(
+            select(self.model, done_subquery, total_subquery)
+            .join(user_user, user_user.c.user_id == User.id)
+            .where(user_user.c.chief_id == user_id)
+            .options(joinedload(User.pdp))
+        )
+        users = db_obj.all()
+        return list(self._add_user_statistic_generator(users))
 
 
 user_crud = CRUDUser(User)

--- a/app/models/pdp.py
+++ b/app/models/pdp.py
@@ -13,4 +13,4 @@ class PDP(AbstractDatesModel):
     goal = Column(String(LENGTH_LIMITS_STRING_FIELDS), nullable=False)
 
     tasks = relationship("Task", back_populates="pdp")
-    user = relationship("User", back_populates="pdp")
+    user = relationship("User", back_populates="pdp", uselist=False)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -54,4 +54,4 @@ class User(SQLAlchemyBaseUserTable[int], Base):
     )
     photo = Column(String(LENGTH_LIMITS_LINK_FIELDS))
 
-    pdp = relationship("PDP", back_populates="user")
+    pdp = relationship("PDP", back_populates="user", uselist=False)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -2,4 +2,4 @@
 from .pdp import PDPCreate, PDPRead, PDPUpdate
 from .task import TaskCreate, TaskRead, TaskUpdate
 from .task_properties import StatusRead, TypeRead
-from .user import UserCreate, UserRead, UserUpdate
+from .user import UserCreate, UserRead, UserShort, UserUpdate

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from fastapi_users.schemas import BaseUser, BaseUserCreate
 from pydantic import BaseModel
 
@@ -9,14 +7,23 @@ from .pdp import PDPShort
 
 
 class UserRead(BaseUser[int]):
-    created: datetime
     first_name: str
     last_name: str
     patronymic_name: str | None = None
     position: str
     role: UserRole
     photo: str | None = None
-    pdp_list: list[PDPShort]
+
+
+class UserShort(BaseModel):
+    id: int
+    first_name: str
+    last_name: str
+    patronymic_name: str | None = None
+    position: str
+    role: UserRole
+    photo: str | None = None
+    pdp: PDPShort
 
 
 class UserCreate(BaseUserCreate):


### PR DESCRIPTION
# Add:

- employee endpoint database logic
- employee crud
- statistic mixin (add statistic data `done` and `total` to `PDP` object)
- PDP crud method to execute data 
##
# Fix: 

- user schema and model _(1to1 relationship `PDP` and `User`)_
- use `PDP` against `self.model` at CRUDpdp

---

Вынес логику создания `done` и `total` подзапросов. Код получился тяжелчитаемым и непонятным, поэтому вернул обратно